### PR TITLE
fix: use symbol as a key for the "others" handler

### DIFF
--- a/src/__tests__/__snapshots__/create-handler-map.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/create-handler-map.dts.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createHandlerMap handle([increment, increase], (state: number) => state + 1) (type) should match snapshot 1`] = `"HandlerMap<number, { type: \\"[Counter] increment\\"; } | { type: \\"[Counter] increase\\"; }, number>"`;
+exports[`createHandlerMap handle([increment, increase], (state: number) => state + 1) (type) should match snapshot 1`] = `"CustomHandlerMap<number, { type: \\"[Counter] increment\\"; } | { type: \\"[Counter] increase\\"; }, number>"`;
 
-exports[`createHandlerMap handle(increment, (state: number) => state + 1) (type) should match snapshot 1`] = `"HandlerMap<number, { type: \\"[Counter] increment\\"; }, number>"`;
+exports[`createHandlerMap handle(increment, (state: number) => state + 1) (type) should match snapshot 1`] = `"CustomHandlerMap<number, { type: \\"[Counter] increment\\"; }, number>"`;
 
-exports[`createHandlerMap handle.others((state: number) => state + 1) (type) should match snapshot 1`] = `"{ default: Handler<number, any, number>; }"`;
+exports[`createHandlerMap handle.others((state: number) => state + 1) (type) should match snapshot 1`] = `"OthersHandlerMap<number, any, number>"`;

--- a/src/__tests__/create-handler-map.spec.ts
+++ b/src/__tests__/create-handler-map.spec.ts
@@ -1,5 +1,5 @@
 import { createActionCreator } from '../create-action-creator'
-import { createHandlerMap as handle } from '../create-handler-map'
+import { createHandlerMap as handle, othersHandlerKey } from '../create-handler-map'
 
 describe('createHandlerMap', () => {
   it('should belong one action to one handler', () => {
@@ -19,6 +19,6 @@ describe('createHandlerMap', () => {
 
   it('should put the "others" handler by "default" key', () => {
     const reducer = (state: number) => state + 1
-    expect(handle.others(reducer)).toEqual({ default: reducer });
+    expect(handle.others(reducer)).toEqual({ [othersHandlerKey]: reducer });
   })
 })

--- a/src/create-handler-map.ts
+++ b/src/create-handler-map.ts
@@ -15,22 +15,23 @@ type OthersHandlerMap<
   TPrevState,
   TAction extends AnyAction,
   TNextState extends TPrevState = TPrevState
-> = { [othersHandlerKey]?: Handler<TPrevState, TAction, TNextState> }
+> = { [othersHandlerKey]: Handler<TPrevState, TAction, TNextState> }
 
 export type HandlerMap<
   TPrevState,
   TAction extends AnyAction,
   TNextState extends TPrevState = TPrevState
-> = CustomHandlerMap<TPrevState, TAction, TNextState> &
-  OthersHandlerMap<TPrevState, TAction, TNextState>
+> =
+  | CustomHandlerMap<TPrevState, TAction, TNextState>
+  | OthersHandlerMap<TPrevState, TAction, TNextState>
 
 export type InferActionFromHandlerMap<
   THandlerMap extends HandlerMap<any, any>
-> = THandlerMap extends HandlerMap<any, infer T> ? T : never
+> = THandlerMap extends CustomHandlerMap<any, infer T> ? T : never
 
 export type InferNextStateFromHandlerMap<
   THandlerMap extends HandlerMap<any, any>
-> = THandlerMap extends HandlerMap<any, any, infer T> ? T : never
+> = THandlerMap extends CustomHandlerMap<any, any, infer T> ? T : never
 
 type InferActionFromCreator<TActionCreator> = TActionCreator extends (...args: any[]) => infer T ? T : never
 
@@ -65,31 +66,32 @@ export type CreateHandlerMap<TPrevState> = CreateCustomHandlerMap<TPrevState> & 
  * @example
  * createHandlerMap.others((state: number) => state + 1)
  */
-export const createHandlerMap = Object.assign(
-  <
-    TActionCreator extends ActionCreator<any>,
-    TPrevState,
-    TNextState extends TPrevState,
-    TAction extends AnyAction = InferActionFromCreator<TActionCreator>
-    >(
-    actionCreators: TActionCreator | TActionCreator[],
-    handler: Handler<TPrevState, TAction, TNextState>
-  ) => {
-    return (Array.isArray(actionCreators) ? actionCreators : [actionCreators])
-      .map(getType)
-      .reduce<CustomHandlerMap<TPrevState, TAction, TNextState>>((acc, type) => {
-        acc[type] = handler
-        return acc
-      }, {} as any)
-  },
-  {
-    others: <
-      TActionCreator extends ActionCreator<any>,
-      TPrevState,
-      TNextState extends TPrevState,
-      TAction extends AnyAction = InferActionFromCreator<TActionCreator>
-      >(
-      handler: Handler<TPrevState, TAction, TNextState>
-    ) => ({ [othersHandlerKey]: handler }) as OthersHandlerMap<TPrevState, TAction, TNextState>
-  }
-)
+export function createHandlerMap<
+  TActionCreator extends ActionCreator<any>,
+  TPrevState,
+  TNextState extends TPrevState,
+  TAction extends AnyAction = InferActionFromCreator<TActionCreator>
+>(
+  actionCreators: TActionCreator | TActionCreator[],
+  handler: Handler<TPrevState, TAction, TNextState>
+): CustomHandlerMap<TPrevState, TAction, TNextState> {
+  return (Array.isArray(actionCreators) ? actionCreators : [actionCreators])
+    .map(getType)
+    .reduce<CustomHandlerMap<TPrevState, TAction, TNextState>>((acc, type) => {
+      acc[type] = handler
+      return acc
+    }, {} as any)
+}
+
+createHandlerMap.others = createOthersHandlerMap
+
+function createOthersHandlerMap<
+  TActionCreator extends ActionCreator<any>,
+  TPrevState,
+  TNextState extends TPrevState,
+  TAction extends AnyAction = InferActionFromCreator<TActionCreator>
+>(
+  handler: Handler<TPrevState, TAction, TNextState>
+): OthersHandlerMap<TPrevState, TAction, TNextState> {
+  return { [othersHandlerKey]: handler }
+}

--- a/src/create-handler-map.ts
+++ b/src/create-handler-map.ts
@@ -48,7 +48,7 @@ export type CreateHandlerMap<TPrevState> = CreateCustomHandlerMap<TPrevState> & 
  * @example
  * createHandlerMap([increment, increase], (state: number) => state + 1)
  * @example
- * createHandlerMap.default((state: number) => state + 1)
+ * createHandlerMap.others((state: number) => state + 1)
  */
 export const createHandlerMap = Object.assign(
   <

--- a/src/create-handler-map.ts
+++ b/src/create-handler-map.ts
@@ -25,6 +25,13 @@ export type HandlerMap<
   | CustomHandlerMap<TPrevState, TAction, TNextState>
   | OthersHandlerMap<TPrevState, TAction, TNextState>
 
+export type MergedHandlerMap<
+  TPrevState,
+  TAction extends AnyAction,
+  TNextState extends TPrevState = TPrevState
+> = CustomHandlerMap<TPrevState, TAction, TNextState> &
+  OthersHandlerMap<TPrevState, TAction, TNextState>
+
 export type InferActionFromHandlerMap<
   THandlerMap extends HandlerMap<any, any>
 > = THandlerMap extends CustomHandlerMap<any, infer T> ? T : never

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -31,11 +31,8 @@ export function createReducer<
     state = defaultState,
     action: InferActionFromHandlerMap<THandlerMap> | AnyAction
   ): InferNextStateFromHandlerMap<THandlerMap> => {
-    const handler = handlerMap[(<any>action).type]
-    const othersHandler = handlerMap[othersHandlerKey]
+    const handler = handlerMap[(<any>action).type] || handlerMap[othersHandlerKey]
 
-    return handler ? handler(<any>state, action) :
-      othersHandler ? othersHandler(<any>state, action) :
-        state
+    return handler ? handler(<any>state, action) : state
   }
 }

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -1,5 +1,6 @@
 import {
   createHandlerMap,
+  othersHandlerKey,
   CreateHandlerMap,
   HandlerMap,
   InferActionFromHandlerMap,
@@ -31,9 +32,10 @@ export function createReducer<
     action: InferActionFromHandlerMap<THandlerMap> | AnyAction
   ): InferNextStateFromHandlerMap<THandlerMap> => {
     const handler = handlerMap[(<any>action).type]
+    const othersHandler = handlerMap[othersHandlerKey]
 
     return handler ? handler(<any>state, action) :
-      handlerMap.default ? handlerMap.default(<any>state, action) :
+      othersHandler ? othersHandler(<any>state, action) :
         state
   }
 }

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -5,6 +5,7 @@ import {
   HandlerMap,
   InferActionFromHandlerMap,
   InferNextStateFromHandlerMap,
+  MergedHandlerMap,
 } from './create-handler-map'
 import { merge } from './utils'
 import { AnyAction } from './create-action'
@@ -25,13 +26,16 @@ export function createReducer<
   defaultState: TPrevState,
   handlerMapsCreator: (handle: CreateHandlerMap<TPrevState>) => THandlerMap[]
 ) {
-  const handlerMap = merge(...handlerMapsCreator(createHandlerMap))
+  const handlerMap: MergedHandlerMap<TPrevState, any, any> = merge(
+    ...handlerMapsCreator(createHandlerMap)
+  )
 
   return (
     state = defaultState,
     action: InferActionFromHandlerMap<THandlerMap> | AnyAction
   ): InferNextStateFromHandlerMap<THandlerMap> => {
-    const handler = handlerMap[(<any>action).type] || handlerMap[othersHandlerKey]
+    const handler =
+      handlerMap[(<AnyAction>action).type] || handlerMap[othersHandlerKey]
 
     return handler ? handler(<any>state, action) : state
   }

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -1,5 +1,4 @@
-export const merge = <T extends {}>(...objs: T[]): T =>
-  Object.assign({}, ...objs)
+export const merge = <T>(...objs: T[]): any => Object.assign({}, ...objs)
 
 export function castArray<TValue>(
   value: TValue | ReadonlyArray<TValue>


### PR DESCRIPTION
I believe the work is mostly finished. I only have one typing issue, but I'm not sure if it's a problem.
When I run dts tests, [one for createReducer](https://github.com/the-dr-lazy/deox/blob/9c93e3842fc8d9cdab264440be000b20bc990e31/src/__tests__/create-reducer.dts.spec.ts#L76) falis (it worked previously, but some other types were not correct). In [this](https://github.com/the-dr-lazy/deox/blob/9c93e3842fc8d9cdab264440be000b20bc990e31/src/__tests__/__snapshots__/create-reducer.dts.spec.ts.snap#L5) line it determines the action type as `any`.

I don't know if there's any use of an exact action type for a reducer and assume that such behavior shouldn't be dangerous. As well as it affects only the new `handle.others` feature, so it's back compatible.

My question is: is it OK to have the `any` type there, or should I try and find some way for a better structure for type inferring?